### PR TITLE
Fix error with type of userId variable

### DIFF
--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -46,7 +46,7 @@ class CentrifugoBroadcaster extends Broadcaster
         $channel = $request->get('channel');
         $this->verifyUserCanAccessChannel($request, $channel);
 
-        return response($this->makeResponseForClient($channel, $client));
+        return response($this->makeResponseForClient($channel, (string)$client));
     }
 
     /**


### PR DESCRIPTION
When you use a middleware 'auth:api' from laravel/passport package on broadcast routes you will see this error:
`Opekunov\Centrifugo\CentrifugoBroadcaster::makeResponseForClient(): Argument #2 ($userId) must be of type string, int given`